### PR TITLE
Typo in install line.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ To install:
 
 .. code-block:: bash
 
-    pip install agatelookup
+    pip install agate-lookup
 
 For details on development or supported platforms see the `agate documentation <http://agate.readthedocs.org>`_.
 


### PR DESCRIPTION
`pip install agatelookup` should be `pip install agate-lookup`
